### PR TITLE
fix: resolve golangci-lint errors

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -373,8 +373,8 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	switch msg.Type {
-	case tea.MouseLeft:
+	// Handle left mouse button press
+	if msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress {
 		// Calculate which worktree was clicked
 		// Account for header (2 lines) and box padding
 		headerHeight := 3
@@ -384,9 +384,6 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if clickedRow >= 0 && clickedRow < len(m.filteredWorktrees) {
 			m.cursor = clickedRow
 		}
-	case tea.MouseRelease:
-		// Double-click detection would need timing logic
-		// For now, we just select on click
 	}
 
 	return m, nil

--- a/internal/exec/open.go
+++ b/internal/exec/open.go
@@ -92,7 +92,8 @@ func OpenWithConfig(cfg *config.Config, wt *git.Worktree) (bool, error) {
 
 	// Apply layout if new window and layout is configured
 	if isNewWindow && cfg.Open.Layout != "none" && cfg.Open.Layout != "" {
-		applyLayout(cfg, wt, repo)
+		// Layout errors are non-fatal - we still opened the window successfully
+		_ = applyLayout(cfg, wt, repo)
 	}
 
 	return isNewWindow, nil

--- a/internal/git/pr.go
+++ b/internal/git/pr.go
@@ -141,7 +141,7 @@ func ListStashes(worktreePath string) ([]StashEntry, error) {
 		// Extract index from stash@{N}
 		indexStr := parts[0]
 		var index int
-		fmt.Sscanf(indexStr, "stash@{%d}", &index)
+		_, _ = fmt.Sscanf(indexStr, "stash@{%d}", &index)
 
 		msg := ""
 		if len(parts) == 2 {

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/henrilemoine/grove/internal/config"
 	"github.com/henrilemoine/grove/internal/git"
 )
@@ -658,16 +657,4 @@ func compactHelp(full, compact string, width int) string {
 		return full
 	}
 	return compact
-}
-
-// padRight pads a string to the right.
-func padRight(s string, width int) string {
-	visibleLen := lipgloss.Width(s)
-	if visibleLen >= width {
-		if len(s) > width-1 {
-			return s[:width-1] + "…"
-		}
-		return s
-	}
-	return s + strings.Repeat(" ", width-visibleLen)
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -254,14 +254,9 @@ func detectTheme() ColorPalette {
 		return lightPalette
 	}
 
-	// macOS Terminal.app defaults to light
-	if termProgram == "Apple_Terminal" {
-		// Check if it's using a dark profile
-		if os.Getenv("TERM_PROGRAM_VERSION") != "" {
-			// Default to system appearance - could be either
-			// Fall through to dark as safer default
-		}
-	}
+	// macOS Terminal.app - we can't reliably detect its theme,
+	// so fall through to dark as the safer default for most terminals
+	_ = termProgram // Acknowledge we checked it
 
 	// Default to dark theme (most common in terminals)
 	return darkPalette


### PR DESCRIPTION
## Summary

Fixes CI lint failures on main branch.

### Changes
- **styles.go**: Remove empty branch that triggered SA9003 warning
- **app.go**: Update deprecated `tea.MouseLeft`/`tea.MouseRelease`/`msg.Type` to use new `MouseAction`/`MouseButton` API
- **render.go**: Remove unused `padRight` function and its lipgloss import
- **open.go**: Explicitly ignore error from `applyLayout` (non-fatal)
- **pr.go**: Explicitly ignore error from `fmt.Sscanf` (parsing best-effort)

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes all tests
- [ ] CI lint job passes